### PR TITLE
Image picker - Adding check for camera permission.

### DIFF
--- a/library/src/main/java/com/mvc/imagepicker/ImagePicker.java
+++ b/library/src/main/java/com/mvc/imagepicker/ImagePicker.java
@@ -16,9 +16,11 @@
 
 package com.mvc.imagepicker;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.AssetFileDescriptor;
 import android.graphics.Bitmap;
@@ -27,6 +29,7 @@ import android.net.Uri;
 import android.os.Parcelable;
 import android.provider.MediaStore;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 import java.io.File;
@@ -111,11 +114,15 @@ public final class ImagePicker {
 
         Intent pickIntent = new Intent(Intent.ACTION_PICK,
                 android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
-        Intent takePhotoIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-        takePhotoIntent.putExtra("return-data", true);
-        takePhotoIntent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(getTemporalFile(context)));
         intentList = addIntentsToList(context, intentList, pickIntent);
-        intentList = addIntentsToList(context, intentList, takePhotoIntent);
+
+        // Camera action will fail if the app does not have permission, check before adding intent.
+        if (hasCameraAccess(context)) {
+            Intent takePhotoIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+            takePhotoIntent.putExtra("return-data", true);
+            takePhotoIntent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(getTemporalFile(context)));
+            intentList = addIntentsToList(context, intentList, takePhotoIntent);
+        }
 
         if (intentList.size() > 0) {
             chooserIntent = Intent.createChooser(intentList.remove(intentList.size() - 1),
@@ -138,6 +145,15 @@ public final class ImagePicker {
             Log.i(TAG, "App package: " + packageName);
         }
         return list;
+    }
+
+    /**
+     * Checks if the current context has permission to access the camera.
+     * @param context             context.
+     */
+    private static boolean hasCameraAccess(Context context) {
+        return ContextCompat.checkSelfPermission(context,
+                Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
     }
 
     /**

--- a/library/src/main/java/com/mvc/imagepicker/ImagePicker.java
+++ b/library/src/main/java/com/mvc/imagepicker/ImagePicker.java
@@ -34,6 +34,7 @@ import android.util.Log;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -219,16 +220,16 @@ public final class ImagePicker {
 
         try {
             fileDescriptor = context.getContentResolver().openAssetFileDescriptor(theUri, "r");
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        }
-
-        if (fileDescriptor != null) {
             actuallyUsableBitmap = BitmapFactory
                     .decodeFileDescriptor(fileDescriptor.getFileDescriptor(), null, options);
             Log.i(TAG, "Trying sample size " + options.inSampleSize + "\t\t"
                     + "Bitmap width: " + actuallyUsableBitmap.getWidth()
                     + "\theight: " + actuallyUsableBitmap.getHeight());
+            fileDescriptor.close();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
         }
 
         return actuallyUsableBitmap;


### PR DESCRIPTION
Since android 6.0, apps need to have permission to use the camera `ACTION_IMAGE_CAPTURE` intent.
The current ImagePicker displays the camera icon in the intent-drawer even when the user has refused camera access to the app.

This pull request prevents the camera icon to be shown when the user has denied camera access.

Edit: I've also added a fix for a memory leak caused by not closing the file handle when reading the bitmap from the saved file.

@Mariovc I have thought about updating the readme, but it seems kind of strange to explain users of the library how to request camera permission. But maybe the sample app needs to be updated. What do you think?