### PR TITLE
Adding nullcheck to prevent crashes on galaxy S5

### DIFF
--- a/library/src/main/java/com/mvc/imagepicker/ImagePicker.java
+++ b/library/src/main/java/com/mvc/imagepicker/ImagePicker.java
@@ -255,9 +255,11 @@ public final class ImagePicker {
             fileDescriptor = context.getContentResolver().openAssetFileDescriptor(theUri, "r");
             actuallyUsableBitmap = BitmapFactory
                     .decodeFileDescriptor(fileDescriptor.getFileDescriptor(), null, options);
-            Log.i(TAG, "Trying sample size " + options.inSampleSize + "\t\t"
-                    + "Bitmap width: " + actuallyUsableBitmap.getWidth()
-                    + "\theight: " + actuallyUsableBitmap.getHeight());
+            if(actuallyUsableBitmap != null) {
+                Log.i(TAG, "Trying sample size " + options.inSampleSize + "\t\t"
+                        + "Bitmap width: " + actuallyUsableBitmap.getWidth()
+                        + "\theight: " + actuallyUsableBitmap.getHeight());
+            }
             fileDescriptor.close();
         } catch (FileNotFoundException e) {
             e.printStackTrace();

--- a/library/src/main/java/com/mvc/imagepicker/ImagePicker.java
+++ b/library/src/main/java/com/mvc/imagepicker/ImagePicker.java
@@ -255,7 +255,7 @@ public final class ImagePicker {
             fileDescriptor = context.getContentResolver().openAssetFileDescriptor(theUri, "r");
             actuallyUsableBitmap = BitmapFactory
                     .decodeFileDescriptor(fileDescriptor.getFileDescriptor(), null, options);
-            if(actuallyUsableBitmap != null) {
+            if (actuallyUsableBitmap != null) {
                 Log.i(TAG, "Trying sample size " + options.inSampleSize + "\t\t"
                         + "Bitmap width: " + actuallyUsableBitmap.getWidth()
                         + "\theight: " + actuallyUsableBitmap.getHeight());


### PR DESCRIPTION
This line of logging caused nullpointer exceptions to occur on samsung galaxy devices when using the "gallery" app to pick an image.
