### PR TITLE
Remove android:allowBackup application attribute

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
     package="com.mvc.imagepicker">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 


### PR DESCRIPTION
The default value is true and having this attribute can conflict with apps that want to set it to false (causing build failures).