### PR TITLE
Fix NPE when using ImagePicker as library

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
         android:supportsRtl="true">
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="${applicationId}.provider"
+            android:authorities="com.mvc.imagepicker.provider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data


### PR DESCRIPTION
The authorities will be not match since application id will match the project package not com.mvc.imagepicker