### PR TITLE
Fixed file not found exception on newer Android versions

### DIFF
--- a/library/src/main/java/com/mvc/imagepicker/ImageRotator.java
+++ b/library/src/main/java/com/mvc/imagepicker/ImageRotator.java
@@ -20,10 +20,15 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Matrix;
-import android.media.ExifInterface;
 import android.net.Uri;
 import android.provider.MediaStore;
 import android.util.Log;
+
+import java.io.File;
+import java.io.InputStream;
+
+import android.media.ExifInterface;
+
 
 /**
  * Author: Mario Velasco Casquero
@@ -62,8 +67,17 @@ public final class ImageRotator {
         int rotate = 0;
         try {
 
+            File file = new File(imageFile.toString());
             context.getContentResolver().notifyChange(imageFile, null);
-            ExifInterface exif = new ExifInterface(imageFile.getPath());
+
+            InputStream inputStream = context.getContentResolver().openInputStream(imageFile);
+
+            ExifInterface exif = null;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                exif = new ExifInterface(inputStream);
+            } else {
+               exif = new ExifInterface(imageFile.getPath());
+            }
             int orientation = exif.getAttributeInt(
                     ExifInterface.TAG_ORIENTATION,
                     ExifInterface.ORIENTATION_NORMAL);

--- a/library/src/main/java/com/mvc/imagepicker/ImageRotator.java
+++ b/library/src/main/java/com/mvc/imagepicker/ImageRotator.java
@@ -24,7 +24,6 @@ import android.net.Uri;
 import android.provider.MediaStore;
 import android.util.Log;
 
-import java.io.File;
 import java.io.InputStream;
 
 import android.media.ExifInterface;
@@ -67,13 +66,10 @@ public final class ImageRotator {
         int rotate = 0;
         try {
 
-            File file = new File(imageFile.toString());
-            context.getContentResolver().notifyChange(imageFile, null);
-
-            InputStream inputStream = context.getContentResolver().openInputStream(imageFile);
-
             ExifInterface exif = null;
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                context.getContentResolver().notifyChange(imageFile, null);
+                InputStream inputStream = context.getContentResolver().openInputStream(imageFile);
                 exif = new ExifInterface(inputStream);
             } else {
                exif = new ExifInterface(imageFile.getPath());


### PR DESCRIPTION
The ImageRotater.java class needed to initialize the ExifInterface with a stream to avoid FileNotFoundException for Android N and up.

Fixes and closes #51 